### PR TITLE
Fix type hint for save_app_data

### DIFF
--- a/src/saleor_app/app.py
+++ b/src/saleor_app/app.py
@@ -14,7 +14,7 @@ class SaleorApp(FastAPI):
         *,
         manifest: Manifest,
         validate_domain: Callable[[DomainName], Awaitable[bool]],
-        save_app_data: Callable[[DomainName, WebhookData], Awaitable],
+        save_app_data: Callable[[DomainName, str, WebhookData], Awaitable],
         use_insecure_saleor_http: bool = False,
         development_auth_token: Optional[str] = None,
         **kwargs,


### PR DESCRIPTION
The type hint currently is misleading, the `save_app_data` function should take three arguments, instead of two. 

https://github.com/saleor/saleor-app-framework-python/blob/main/src/saleor_app/endpoints.py#L61-L65